### PR TITLE
Fix permissions and genericize mountpoint in hook

### DIFF
--- a/mkinitcpio-overlayfs.hook
+++ b/mkinitcpio-overlayfs.hook
@@ -1,18 +1,19 @@
 #!/bin/sh
 
 ROOT_MNT="/new_root"
-OFS_DIRS="/run/archroot"
-OFS_LOWER="${OFS_DIRS}/root_ro"
+OFS_DIRS="/run/rootfs"
+OFS_LOWER="${OFS_DIRS}/lower"
 OFS_COWSPACE="${OFS_DIRS}/cowspace"
 OFS_UPPER="${OFS_COWSPACE}/upper"
 OFS_WORK="${OFS_COWSPACE}/work"
 
 run_latehook() {
 	[ -d ${OFS_LOWER} ] || mkdir -p ${OFS_LOWER}
+
 	mount --move ${ROOT_MNT} ${OFS_LOWER}
 
 	mkdir -p ${OFS_COWSPACE}
-	mount -t tmpfs cowspace ${OFS_COWSPACE}
+	mount -t tmpfs -o mode=0755 cowspace ${OFS_COWSPACE}
 
 	[ -d ${OFS_UPPER} ] || mkdir -p ${OFS_UPPER}
 	[ -d ${OFS_WORK} ] || mkdir -p ${OFS_WORK}


### PR DESCRIPTION
This hook has utility outside of Arch, so I propose a more generic `/run/rootfs`. Also, there's no need for mode `1777` on `cowspace`; the permissions can be made more restrictive.